### PR TITLE
pdfauthor -> Eliezer Yudkowsky

### DIFF
--- a/hp-header.tex
+++ b/hp-header.tex
@@ -13,7 +13,7 @@
 
 \usepackage[bookmarks=true,unicode=true,pdfborder={0 0 0},
 	pdftitle={Harry Potter and the Methods of Rationality},
-	pdfauthor={LessWrong}, breaklinks={true},
+	pdfauthor={Eliezer Yudkowsky}, breaklinks={true},
 	pdfkeywords={Harry Potter, rationality},pdfencoding=auto
 ]{hyperref}
 


### PR DESCRIPTION
I suggest the PDF author field should be Eliezer Yudkowsky instead of his penname LessWrong.